### PR TITLE
Disable Minions calling for help from ALL other minions in area

### DIFF
--- a/src/main/java/com/projectreddog/deathcube/entity/EntityMinion.java
+++ b/src/main/java/com/projectreddog/deathcube/entity/EntityMinion.java
@@ -51,7 +51,7 @@ public class EntityMinion extends EntityMob {
 	}
 
 	protected void applyEntityAI() {
-		this.targetTasks.addTask(1, new EntityAIHurtByTarget(this, true, new Class[] { EntityPigZombie.class }));
+		this.targetTasks.addTask(1, new EntityAIHurtByTarget(this, false, new Class[] { EntityPigZombie.class }));
 		this.targetTasks.addTask(2, new EntityAINearestAttackableTargetNotTeam(this, EntityPlayer.class, true, team));
 	}
 


### PR DESCRIPTION
could possibly override and cause it call for help if on same team but
this is simpler and probably better
